### PR TITLE
Add parse-str to allow more flexible usage.

### DIFF
--- a/src/frontmatter/core.clj
+++ b/src/frontmatter/core.clj
@@ -31,12 +31,16 @@
     "###" parse-edn
     nil))
 
-(defn parse
-  [path]
-  (let [original-body             (-> path slurp str/trim)
+(defn parse-str
+  [string]
+  (let [original-body             string
         [first-line & rest-lines] (str/split-lines original-body)
         [frontmatter body]        (split-lines rest-lines first-line)]
     (if-let [parser (select-parse-fn first-line)]
       {:body (str/join "\n" body)
        :frontmatter (parser (str/join "\n" frontmatter))}
       {:frontmatter {} :body original-body})))
+
+(defn parse
+  [path]
+  (parse-str (-> path slurp str/trim)))


### PR DESCRIPTION
There is no reason that I can see to restrict the consumer of this api
to files only.
